### PR TITLE
Changes to support embedded container image

### DIFF
--- a/rancheros/Dockerfile
+++ b/rancheros/Dockerfile
@@ -86,5 +86,5 @@ WORKDIR /build
 # ------------------------------------------------
 ENTRYPOINT ["/docker-entrypoint.py"]
 CMD ["--help"]
-EXPOSE 5900
+EXPOSE 5910 5911
 

--- a/rancheros/cloud-config.yml
+++ b/rancheros/cloud-config.yml
@@ -1,7 +1,6 @@
 #cloud-config
 ssh_authorized_keys:
   - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDlrcxixjMKV4I9c4dlhddYipV9mMbCkA4UM/oQbo/JG1fhnNdNxQWN0WB2UEAXaepPPJpFh5Do2P4YApjSRSN9J5pCktF+bHh3lb5t5n8GuvRzSfmBBAoBY6efyWU+86TF/7OwtQz0ADDK56VoTW9/N5iTlbGcKSQk5XmPDkRInzbPmj9/0a4yP/km4ytu5viueCT3rEOfcogWZdc6TYqc+zznYWT5PpEU6DUIQxiu5oyH5ToHICnwxehfyFv5qXauH1Z6+CQ4hFRgJFPUO2DjG8E8qiTziEN8jP6GjucMBpi2hYADlHHAIQkDOfku/ulvifQfc0qS5/4ghL/0/08l jcallen@silicon.virtomation.com
-  
 rancher:
     services: 
         alpine-ansible-ssh:

--- a/rancheros/docker-compose.yml
+++ b/rancheros/docker-compose.yml
@@ -6,8 +6,9 @@ services:
 # Privileged is required to execute a QEMU/KVM virtual machine in the container  
         privileged: true
         ports:
-            - "0.0.0.0:5900:5900"
-        command: build -only rancher-scsi-e1000 -var 'device=/dev/sda' /opt/hashicorp/etc/packer/rancheros.json
+            - "0.0.0.0:5910:5910"
+            - "0.0.0.0:5911:5911"
+        command: build -only rancher-offline,rancher-online -var 'device=/dev/sda' /opt/hashicorp/etc/packer/rancheros.json
 # This commented environment variable will enable debug logging for Packer
 #       environment:
 #           PACKER_LOG: 1    

--- a/rancheros/minimal.ovf
+++ b/rancheros/minimal.ovf
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
-<ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1">
+<ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf">
   <ovf:References />
-  <ovf:VirtualSystem ovf:id="x">
+  <ovf:VirtualSystem ovf:id="vmw">
     <ovf:Info />
     <ovf:VirtualHardwareSection>
       <ovf:Info />

--- a/rancheros/rancheros.json
+++ b/rancheros/rancheros.json
@@ -8,7 +8,18 @@
 {
   "type": "shell",
   "inline": ["sudo ros install -c /tmp/cloud-config.yml -d {{user `device`}} -f -t generic --no-reboot"]
-}],
+},
+{
+  "type": "shell",
+  "inline": ["sudo docker pull jcpowermac/alpine-ansible-ssh", 
+      "sudo mkdir -p /mnt/img",
+      "sudo mount /dev/sda1 /mnt/img",
+      "sudo mkdir -p /mnt/img/var/lib/rancher/preload/docker",
+      "sudo docker save -o /mnt/img/var/lib/rancher/preload/docker/ansible.tar jcpowermac/alpine-ansible-ssh"
+  ],
+  "only": ["rancher-offline"]
+}
+],
 "builders": [{
       "name": "rancheros-virtio",
       "type": "qemu",
@@ -38,7 +49,7 @@
         ]
     },
     { 
-      "name": "rancher-scsi-e1000",
+      "name": "rancher-online",
       "type": "qemu",
       "iso_checksum_type": "sha256",
       "iso_checksum": "{{ user `iso_checksum`}}",
@@ -58,32 +69,59 @@
       "ssh_wait_timeout": "90m",
       "net_device": "e1000",
       "disk_interface": "scsi",
-      "vnc_port_min": 5900,
-      "vnc_port_max": 5900,
+      "vnc_port_min": 5910,
+      "vnc_port_max": 5910,
       "qemuargs": [
           [ "-m", "1024M" ]
+        ]
+    },
+    { 
+      "name": "rancher-offline",
+      "type": "qemu",
+      "iso_checksum_type": "sha256",
+      "iso_checksum": "{{ user `iso_checksum`}}",
+      "iso_url": "{{ user `iso_url`}}",
+      "output_directory": "/build/output",
+      "ssh_wait_timeout": "30s",
+      "shutdown_command": "sudo poweroff",
+      "disk_size": 8192,
+      "format": "qcow2",
+      "headless": true,
+      "accelerator": "kvm",
+      "ssh_host_port_min": 2222,
+      "ssh_host_port_max": 2229,
+      "ssh_username": "rancher",
+      "ssh_password": "rancher",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "90m",
+      "net_device": "e1000",
+      "disk_interface": "scsi",
+      "vnc_port_min": 5911,
+      "vnc_port_max": 5911,
+      "qemuargs": [
+          [ "-m", "2048M" ]
         ]
     }],
 "post-processors": [
     {
         "type": "shell-local",
-        "inline": "qemu-img convert -f qcow2 -O vmdk /build/output/packer-rancher-scsi-e1000 /build/output/rancher.vmdk",
-        "only": ["rancher-scsi-e1000"]
+        "inline": "qemu-img convert -f qcow2 -O vmdk /build/output/packer-{{build_name}} /build/output/{{build_name}}.vmdk",
+        "only": ["rancher-online","rancher-offline"]
     },
     {
         "type": "shell-local",
-        "inline": "cot -f edit-product /opt/hashicorp/etc/packer/minimal.ovf -o /build/output/rancher.ovf -p RancherOS -n Rancher -v 0.5.0",
-        "only": ["rancher-scsi-e1000"]
+        "inline": "cot -f edit-product /opt/hashicorp/etc/packer/minimal.ovf -o /build/output/{{build_name}}.ovf -p RancherOS -n Rancher -v 0.5.0",
+        "only": ["rancher-online","rancher-offline"]
     },
     {
         "type": "shell-local",
-        "inline": "cot -f edit-hardware /build/output/rancher.ovf -v vmx-8 -c 1 -m 1G -n 1 --nic-types e1000 --nic-names eth0 --nic-networks eth0 --network-descriptions \"Management Network\"",
-        "only": ["rancher-scsi-e1000"]
+        "inline": "cot -f edit-hardware /build/output/{{build_name}}.ovf -v vmx-8 -c 1 -m 4G -n 1 --nic-types e1000 --nic-names eth0 --nic-networks eth0 --network-descriptions \"Management Network\"",
+        "only": ["rancher-online","rancher-offline"]
     },
     {
         "type": "shell-local",
-        "inline": "cot -f add-disk /build/output/rancher.vmdk /build/output/rancher.ovf -t harddisk -c scsi",
-        "only": ["rancher-scsi-e1000"]
+        "inline": "cot -f add-disk /build/output/{{build_name}}.vmdk /build/output/{{build_name}}.ovf -t harddisk -c scsi",
+        "only": ["rancher-online","rancher-offline"]
     }
 ]
 }


### PR DESCRIPTION
Created an on and offline build.  Modified `rancheros.json` accordingly to support this.
Including the proper commands to _save_ the image locally after the installation of RancherOS

Modified `docker-compose.yml` to support the building of both on and offline.
Needed to modify the VNC ports since two builders were running at the same time and being blocked
with no available port.

Increased the amount of memory required to 4GB in offline mode.  This number could be lowered just what it was
tested with.  Otherwise there is a race condition that the compose operation happens before the preload can complete.
