### PR TITLE
Adding Python Butterfly alpine image

### DIFF
--- a/alpine-ansible-ssh/Dockerfile
+++ b/alpine-ansible-ssh/Dockerfile
@@ -3,5 +3,6 @@ FROM williamyeh/ansible:alpine3
 COPY . /tmp/
 RUN ansible-playbook /tmp/init.yml -c local -i localhost,
 
+USER ansible
 ENTRYPOINT ["/bin/ash"]
 CMD ["-c", "/usr/sbin/sshd -D -e"]

--- a/alpine-butterfly/Dockerfile
+++ b/alpine-butterfly/Dockerfile
@@ -1,0 +1,7 @@
+FROM jcpowermac/alpine-ansible-ssh 
+
+RUN pip install butterfly   
+
+USER ansible
+ENTRYPOINT ["/bin/ash"]
+CMD ["-c", "/usr/bin/butterfly.server.py --unsecure --host=0.0.0.0"]

--- a/alpine-butterfly/README.md
+++ b/alpine-butterfly/README.md
@@ -1,0 +1,25 @@
+
+#### alpine-ansible-ssh
+
+A Docker image with Ansible is already available in the Docker Hub so that is our starting point for this image.
+```
+FROM williamyeh/ansible:alpine3
+```
+The Ansible playbook `init.yml` and the OpenSSH server configuration file is copied to `/tmp`.
+```
+COPY . /tmp/
+```
+Since Ansible is already available it will be used to configure the rest of the image.  Which includes:
+- Installing and configuring OpenSSH
+- Creating the Ansible user account
+- Generating the host's SSH Keys
+- Installing additional python requirements for AWS and Windows
+
+```
+RUN ansible-playbook /tmp/init.yml -c local -i localhost,
+```
+The ash shell is the ENTRYPOINT with the CMD defaulted to run sshd.
+```
+ENTRYPOINT ["/bin/ash"]
+CMD ["-c", "/usr/sbin/sshd -D -e"]
+```

--- a/alpine-butterfly/docker-compose.build.yml
+++ b/alpine-butterfly/docker-compose.build.yml
@@ -1,0 +1,8 @@
+---
+version: '2'
+services:
+    alpine-butterfly:
+        image: jcpowermac/alpine-butterfly
+        build: 
+            context: .
+            dockerfile: Dockerfile

--- a/alpine-butterfly/docker-compose.yml
+++ b/alpine-butterfly/docker-compose.yml
@@ -1,0 +1,7 @@
+---
+version: '2'
+services:
+    alpine-butterfly:
+        image: jcpowermac/alpine-butterfly
+        ports:
+            - "0.0.0.0:57575:57575"


### PR DESCRIPTION
Adding the necessary Docker files to create an image with Ansible along with
the [Butterfly](https://github.com/paradoxxxzero/butterfly) web terminal.

This will allow end-users the ability to use Ansible without install an SSH client.

Also modified the existing Dockerfile for alpine-ansible-ssh - changing the running user to
ansible instead of root.
